### PR TITLE
Change status callbacks from after_save to after_commit hook

### DIFF
--- a/lib/has_states/base.rb
+++ b/lib/has_states/base.rb
@@ -13,7 +13,7 @@ module HasStates
     validate :state_limit_not_exceeded, on: :create
     validate :metadata_conforms_to_schema, if: -> { metadata.present? }
 
-    after_save :trigger_callbacks, if: :saved_change_to_status?
+    after_commit :trigger_callbacks, if: :saved_change_to_status?
 
     private
 


### PR DESCRIPTION
Using after_save once lead us to race condition, when state wasn't updated and callback function performed a check of state before and failed.

Also makes sense if state update would be part of some transaction that might fail and lead to callback be started when it is not intended.